### PR TITLE
Include nixconfig to to use cache

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,17 @@
     inherit inputs;
     repoRoot = ./.;
     outputs = import ./nix/outputs.nix;
-    systems = [ "x86_64-linux" "x86_64-darwin" ];
+    systems = [ "x86_64-linux" ]; # "x86_64-darwin" ];
+  };
+
+  nixConfig = {
+    extra-substituters = [
+      "https://cache.iog.io"
+    ];
+    extra-trusted-public-keys = [
+      "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
+    ];
+    allow-import-from-derivation = true;
   };
 
 }


### PR DESCRIPTION
* Otherwise ghc and friends will be compiled from source.

* There is a nix failure independent of this change which can be fixed by deleting the .pre-commit-config.yaml. This should be checked.