### PR TITLE
Small patch to correct the parser for static files

### DIFF
--- a/src/lib/Wst/Cli/Command.hs
+++ b/src/lib/Wst/Cli/Command.hs
@@ -15,6 +15,7 @@ import Options.Applicative (CommandFields, Mod, Parser, ReadM, argument, auto,
                             command, eitherReader, fullDesc, help, info, long,
                             metavar, option, optional, progDesc, short,
                             subparser, value)
+import Options.Applicative.Builder (strOption)
 import Text.Read (readMaybe)
 import Wst.Server (ServerArgs (..))
 
@@ -64,7 +65,7 @@ parseServerArgs :: Parser ServerArgs
 parseServerArgs =
   ServerArgs
     <$> option auto (help "The port" <> value 8080 <> long "port" <> short 'p')
-    <*> optional (option auto (help "Folder to serve static files from" <> long "static-files"))
+    <*> optional (strOption (help "Folder to serve static files from" <> long "static-files"))
 
 parseTxIn :: Parser TxIn
 parseTxIn =


### PR DESCRIPTION
I think that (optional) string arguments require the strOption to work correctly.
Otherwise, the program compiles but the parser doesn't do what is expected.
[strOption](https://hackage.haskell.org/package/optparse-applicative-0.18.1.0/docs/Options-Applicative.html#v:strOption)
