### PR TITLE
Add cors headers

### DIFF
--- a/src/lib/Wst/Server.hs
+++ b/src/lib/Wst/Server.hs
@@ -18,6 +18,7 @@ import Convex.CardanoApi.Lenses qualified as L
 import Convex.Class (MonadBlockchain, MonadUtxoQuery)
 import Data.Data (Proxy (..))
 import Network.Wai.Handler.Warp qualified as Warp
+import Network.Wai.Middleware.Cors
 import PlutusTx.Prelude qualified as P
 import Servant (Server, ServerT)
 import Servant.API (NoContent (..), Raw, (:<|>) (..))
@@ -58,7 +59,7 @@ defaultServerArgs =
 
 runServer :: (Env.HasRuntimeEnv env, Env.HasDirectoryEnv env) => env -> ServerArgs -> IO ()
 runServer env ServerArgs{saPort, saStaticFiles} = do
-  let app  = case saStaticFiles of
+  let app  = cors (const $ Just simpleCorsResourcePolicy) $ case saStaticFiles of
         Nothing -> serve (Proxy @APIInEra) (server env)
         Just fp -> serve (Proxy @CombinedAPI) (server env :<|> serveDirectoryWebApp fp)
       port = saPort

--- a/src/test/lib/Wst/Test/MockServer.hs
+++ b/src/test/lib/Wst/Test/MockServer.hs
@@ -9,6 +9,7 @@ import Cardano.Api qualified as C
 import Control.Monad.IO.Class (MonadIO (..))
 import Data.Proxy (Proxy (..))
 import Network.Wai.Handler.Warp qualified as Warp
+import Network.Wai.Middleware.Cors
 import Servant (Server)
 import Servant.API (NoContent (..), (:<|>) (..))
 import Servant.Server (serve)
@@ -46,7 +47,7 @@ mockTxApi =
 -- | Start the mock server
 runMockServer :: IO ()
 runMockServer = do
-  let app = serve (Proxy @APIInEra) mockServer
+  let app = simpleCors $ serve (Proxy @APIInEra) mockServer
       port = 8080
   putStrLn $ "Starting mock server on port " <> show port
   Warp.run port app

--- a/src/wst-poc.cabal
+++ b/src/wst-poc.cabal
@@ -119,6 +119,7 @@ library
     , servant-client-core
     , servant-server
     , text
+    , wai-cors
     , warp
 
   hs-source-dirs:  lib
@@ -165,6 +166,7 @@ library test-lib
     , QuickCheck
     , servant
     , servant-server
+    , wai-cors
     , warp
     , wst-poc
 


### PR DESCRIPTION
Introduce wai-cors to add `"Access-Control-Allow-Origin: *"` to api responses.