### PR TITLE
Include root certs

### DIFF
--- a/nix/containers.nix
+++ b/nix/containers.nix
@@ -54,6 +54,10 @@ in rec {
       (inputs.n2c.packages.nix2container.buildLayer {
         copyToRoot = [frontend];
       })
+      # CA certificates for SSL (required for calling blockfrost API)
+      (inputs.n2c.packages.nix2container.buildLayer {
+        copyToRoot = [pkgs.dockerTools.caCertificates];
+      })
     ];
   };
 


### PR DESCRIPTION
We need the certificates in order to make requests to Blockfrost