### PR TITLE
Fix JSON for UTxODat

### DIFF
--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -41,8 +41,3 @@ jobs:
           cabal update
           cabal build -j all --enable-tests
           cabal test all
-      - name: check compiled scripts are consistent
-        # git diff --quiet implies --exit-code
-        run: |
-          cabal run export-smart-tokens
-          git diff --quiet

--- a/generated/openapi/schema.json
+++ b/generated/openapi/schema.json
@@ -179,20 +179,20 @@
             },
             "UTxODat_ConwayEra_ProgrammableLogicGlobalParams": {
                 "properties": {
-                    "atum": {
+                    "datum": {
                         "$ref": "#/components/schemas/ProgrammableLogicGlobalParams"
                     },
-                    "n": {
+                    "in": {
                         "$ref": "#/components/schemas/TxIn"
                     },
-                    "ut": {
+                    "out": {
                         "$ref": "#/components/schemas/TxOut"
                     }
                 },
                 "required": [
-                    "n",
-                    "ut",
-                    "atum"
+                    "in",
+                    "out",
+                    "datum"
                 ],
                 "type": "object"
             },

--- a/src/lib/Wst/Offchain/Query.hs
+++ b/src/lib/Wst/Offchain/Query.hs
@@ -61,7 +61,7 @@ data UTxODat era a =
 
 -- | Aeson options for the UTxODat type. Used to derive JSON instances and ToSchema
 utxoDatOptions :: JSON.Options
-utxoDatOptions = JSON.customJsonOptions 2
+utxoDatOptions = JSON.customJsonOptions 1
 
 instance (C.IsCardanoEra era, ToJSON a) => ToJSON (UTxODat era a) where
   toJSON = JSON.genericToJSON utxoDatOptions


### PR DESCRIPTION
* We were cutting too many characters
* Also delete `check compiled scripts are consistent` from ci-linux.yaml (there is still a separate workflow that tests the generated code)