### PR TITLE
Determine tag *after* checkout

### DIFF
--- a/.github/workflows/ci-oci.yaml
+++ b/.github/workflows/ci-oci.yaml
@@ -29,6 +29,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+    - name: Log in to ghcr.io
+      uses: redhat-actions/podman-login@v1
+      with:
+        username: ${{ env.REGISTRY_USER }}
+        password: ${{ env.REGISTRY_PASSWORD }}
+        registry: ${{ env.IMAGE_REGISTRY }}
+
+    - uses: actions/checkout@v4
+
     - name: Determine image tag for git tag
       if: ${{ github.event_name == 'push' }}
       run: |
@@ -40,15 +49,6 @@ jobs:
       run: |
         IMAGE_TAG=pr-${{ github.event.pull_request.number }}
         echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
-
-    - name: Log in to ghcr.io
-      uses: redhat-actions/podman-login@v1
-      with:
-        username: ${{ env.REGISTRY_USER }}
-        password: ${{ env.REGISTRY_PASSWORD }}
-        registry: ${{ env.IMAGE_REGISTRY }}
-
-    - uses: actions/checkout@v4
 
     - name: Install nix
       uses: cachix/install-nix-action@v27


### PR DESCRIPTION
The git diff doesn't show this properly, but

When running the OCI workflow after a "push" action (for a new tag), we call `git rev-parse` to figure out what the image tag should be. This only works _after_ `actions/checkout`. Before the checkout action there is no github repository and `git rev-parse` fails.

Sadly I only noticed this after having made an official release tag for v0.1.0. So now we'll have to go straight to v0.1.1.