### PR TITLE
Fix obsolete CIP-0143 link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CIP-143 reference implementation and examples
 
-This repository contains a reference implementation of [CIP-143](https://github.com/colll78/CIPs/blob/patch-3/CIP-0143/README.md).
+This repository contains a reference implementation of [CIP-143](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0143/README.md).
 The CIP describes a registry of token standards around programmable assets, and some conventions for Cardano addresses that hold programmable assets.
 
 ## CLI
@@ -24,7 +24,7 @@ The validators will be called as reward withdrawal validators.
 
 ## Freeze-and-seize stablecoin
 
-There is a proof-of-concept for _WST_ a programmable token with freeze and seize capabilities, based on [CIP-0143](https://github.com/colll78/CIPs/blob/patch-3/CIP-0143/README.md). The programmable logic of _WST_ checks whether the target address is blacklisted before allowing a transfer of the programmable token from one owner to another.
+There is a proof-of-concept for _WST_ a programmable token with freeze and seize capabilities, based on [CIP-0143](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0143/README.md). The programmable logic of _WST_ checks whether the target address is blacklisted before allowing a transfer of the programmable token from one owner to another.
 
 ![Screenshot of the UI showing the minting authority.](image-1.png)
 

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -5,7 +5,7 @@ This document describes the design of the regulated stablecoin proof-of-concept 
 ## Overview
 
 The POC consists of two components that make up the functionality of the regulated stablecoin.
-The first component is [CIP-0143](https://github.com/colll78/CIPs/tree/patch-3/CIP-0143), which gives us a unified standard for managing different _programmable tokens_, comparable to some of the popular ERC standards on Ethereum.
+The first component is [CIP-0143](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0143), which gives us a unified standard for managing different _programmable tokens_, comparable to some of the popular ERC standards on Ethereum.
 
 The second component is a concrete instance of such a programmable token, namely a policy that checks each transfer of tokens in its domain to ensure that the sender is not on a list of sanctioned addresses.
 The policy also allows the issuer of the programmable token to seize funds from sanctioned addresses.


### PR DESCRIPTION
CIP-0143 became an officially posted CIP with this merge into the CIPs repository:
* https://github.com/cardano-foundation/CIPs/pull/944

The obsolete branch copy has some incorrect or inconsistent material that was corrected or confirmed in that pull request under @colll78's supervision.

---

A related issue, which I won't try to correct here yet, but would appreciate some cooperation on: the identifiers of these CIPs  are `CIP-0113` AND `CIP-0143`, both **with leading zeroes**.  The Cardano community needs to stick to 4-digit numbers in CIP tags (in addition to the less formal names "CIP 113" and "CIP 143" without the `-`) to avoid search and pattern recognition collisions.  (cc @Ryun1 @perturbing)

We will thank ourselves for this especially in a few years when new 4-digit CIP numbers start beginning with these 3-digit values.  Keeping distinct 4-digit numbers for RFC has helped the Internet get through its first 45 years and it would be nice to see this happen for Cardano as well.

(cc @nemo83 re: [cardano-foundation/cip113-programmable-tokens](https://github.com/cardano-foundation/cip113-programmable-tokens) which also has this problem)