### PR TITLE
bench: record the pair-Case memory investigation (no validator changes)

### DIFF
--- a/src/programmable-tokens-test/exe/BenchmarkOnchainFunctions.hs
+++ b/src/programmable-tokens-test/exe/BenchmarkOnchainFunctions.hs
@@ -668,6 +668,8 @@ benchCases =
     ]
         <> decisionBenchCases
         <> casingDecisionCases
+        <> casingDecision2Cases
+        <> casingDecision3Cases
 
 -- =====================================================================
 -- Decision benchmarks for design-issuance-dual-arm-custody.md pending
@@ -1657,4 +1659,90 @@ casingDecisionCases =
     , mkCase "decision.case.field2.case" casingField2Case []
     , mkCase "decision.case.intDispatch.pif" casingIntDispatchPif []
     , mkCase "decision.case.intDispatch.case" casingIntDispatchCase []
+    ]
+
+-- =====================================================================
+-- Second round of casing decision benchmarks, shaped after the ACTUAL usage
+-- contexts in the converted walks, with every head-to-head computing the same
+-- result (the first round's pairBoth vs pairFst comparison differed by an
+-- AddInteger, so only within-group deltas were fair):
+--   * matchWalk.none — sorted-walk mismatch path: compare fst every
+--     iteration, never touch snd. The builtin variant pays one FstPair; the
+--     Case variant binds both components eagerly and discards snd.
+--   * matchWalk.all — the same walk with every comparison succeeding, so snd
+--     is consumed each iteration (builtin pays FstPair+SndPair).
+-- Together with decision.case.field2.* these cover shapes B (fst-compare,
+-- snd-on-match), C (fst only), A (both, = matchWalk.all) and D (field
+-- chains).
+
+casingMatchWalkNoneBuiltins :: forall s. Term s PInteger
+casingMatchWalkNoneBuiltins = casingWalk (casingPairs @s) $ \acc p ->
+    pif ((pfstBuiltin # p) #== pconstantInteger (-1)) (acc + (psndBuiltin # p)) (acc + pconstantInteger 1)
+
+casingMatchWalkNoneCase :: forall s. Term s PInteger
+casingMatchWalkNoneCase = casingWalk (casingPairs @s) $ \acc p ->
+    pmatch p $ \(PBuiltinPair x y) ->
+        pif (x #== pconstantInteger (-1)) (acc + y) (acc + pconstantInteger 1)
+
+casingMatchWalkAllBuiltins :: forall s. Term s PInteger
+casingMatchWalkAllBuiltins = casingWalk (casingPairs @s) $ \acc p ->
+    pif ((pfstBuiltin # p) #< pconstantInteger 1000000) (acc + (psndBuiltin # p)) (acc + pconstantInteger 1)
+
+casingMatchWalkAllCase :: forall s. Term s PInteger
+casingMatchWalkAllCase = casingWalk (casingPairs @s) $ \acc p ->
+    pmatch p $ \(PBuiltinPair x y) ->
+        pif (x #< pconstantInteger 1000000) (acc + y) (acc + pconstantInteger 1)
+
+casingDecision2Cases :: [BenchCase]
+casingDecision2Cases =
+    [ mkCase "decision.case2.matchWalk.none.builtins" casingMatchWalkNoneBuiltins []
+    , mkCase "decision.case2.matchWalk.none.case" casingMatchWalkNoneCase []
+    , mkCase "decision.case2.matchWalk.all.builtins" casingMatchWalkAllBuiltins []
+    , mkCase "decision.case2.matchWalk.all.case" casingMatchWalkAllCase []
+    ]
+
+-- The two real field-chain shapes, each with every variant computing the same
+-- result:
+--   * fieldPrelude — walk preamble: head (address) AND second field (value)
+--     both consumed. Old form pays phead + ptail + phead (3 builtins); the
+--     Case form one list Case + one phead.
+--   * skipSecond — phasCSH shape: only the SECOND element's fst is consumed,
+--     everything bound on the way is discarded. Variants: 3 builtins; nested
+--     Case (binds 4, discards 3); and a hybrid (builtin ptail, then one list
+--     Case and one pair Case).
+casingFieldPreludeBuiltins :: forall s. Term s PInteger
+casingFieldPreludeBuiltins = casingWalk (casingTags @s) $ \acc _ ->
+    plet casingFieldFixture $ \fields ->
+        acc + (phead # fields) + (phead # (ptail # fields))
+
+casingFieldPreludeCase :: forall s. Term s PInteger
+casingFieldPreludeCase = casingWalk (casingTags @s) $ \acc _ ->
+    pheadTailBuiltin casingFieldFixture $ \h rest ->
+        acc + h + (phead # rest)
+
+casingSkipSecondBuiltins :: forall s. Term s PInteger
+casingSkipSecondBuiltins = casingWalk (casingPairs @s) $ \acc _ ->
+    acc + (pfstBuiltin # (phead # (ptail # casingPairFixtureList)))
+
+casingSkipSecondAllCase :: forall s. Term s PInteger
+casingSkipSecondAllCase = casingWalk (casingPairs @s) $ \acc _ ->
+    pheadTailBuiltin casingPairFixtureList $ \_ rest ->
+        pheadTailBuiltin rest $ \secondEntry _ ->
+            pmatch secondEntry $ \(PBuiltinPair x _) -> acc + x
+
+casingSkipSecondHybrid :: forall s. Term s PInteger
+casingSkipSecondHybrid = casingWalk (casingPairs @s) $ \acc _ ->
+    pheadTailBuiltin (ptail # casingPairFixtureList) $ \secondEntry _ ->
+        pmatch secondEntry $ \(PBuiltinPair x _) -> acc + x
+
+casingPairFixtureList :: forall s. Term s (PBuiltinList (PBuiltinPair PInteger PInteger))
+casingPairFixtureList = pconstant [(i, i) | i <- [1 .. 4 :: Integer]]
+
+casingDecision3Cases :: [BenchCase]
+casingDecision3Cases =
+    [ mkCase "decision.case3.fieldPrelude.builtins" casingFieldPreludeBuiltins []
+    , mkCase "decision.case3.fieldPrelude.case" casingFieldPreludeCase []
+    , mkCase "decision.case3.skipSecond.builtins" casingSkipSecondBuiltins []
+    , mkCase "decision.case3.skipSecond.allCase" casingSkipSecondAllCase []
+    , mkCase "decision.case3.skipSecond.hybrid" casingSkipSecondHybrid []
     ]


### PR DESCRIPTION
> **Correction (see #117):** the in-context adjudication described below — "the hybrid lost in context: fee +0.22%, CPU worse everywhere" — turned out to be a single draw from the hash-reordering noise band (±3.5% per-scenario), not a property of the code. A controlled 3-arm × 4-jitter experiment showed the **pre-#115 builtin form** is the right choice for `phasCSH` (memory separates beyond noise; CPU/fee do not), and #117 makes that change. The op-level microbenches added by this PR remain valid; the lesson is that sub-0.5% in-context claims require jitter distributions, not single runs.

Follow-up to #115, benchmarks only — no validator changes.

#115's pair-Case commit noted small (≤2.2%) memory regressions on the ManyPolicies/ManyTokens shapes. The obvious hypothesis: Case binds both pair components, so sites that only need `fst` are paying memory for an unused binding. This PR records the investigation that DISPROVED that, so the next person doesn't re-litigate it from the same intuition.

New fair (same-computed-result) decision benchmarks:

- `decision.case2.matchWalk.{none,all}` — the sorted-walk shape: compare `fst` each iteration, touch `snd` only on match. Pair Case beats the builtins on BOTH axes even when `snd` is never consumed (CPU −40%, mem −3%). Eager binding is not the problem.
- `decision.case3.fieldPrelude` — head + second field both consumed (the walk-preamble shape): Case wins both axes (CPU −31%, mem −5.6%).
- `decision.case3.skipSecond` — the only genuinely mem-regressing shape at op level (+20%): nested skip-chains that discard most of what they bind. Sole real site: `phasCSH`.

For that one site a mem-optimal hybrid (builtin `ptail` + one list Case + one pair Case) won the microbench tie-break — and then **lost in context**: the 53-scenario suite measured it fee +0.22% aggregate (mainnet prices, 1 mem unit ≈ 800 CPU units), CPU worse everywhere, and its mem wins unreliable. The all-Case form shipped in #115 stands.

Two conclusions worth keeping:

1. Scenario-level memory shifts from single-site tweaks exceed the op-level arithmetic by orders of magnitude (hoisting/sharing interactions) — the suite, not the microbench, adjudicates final placement.
2. Fee-weighted, #115's casing work nets **−9.56%**; the residual ManyPolicies mem (+0.2–1.15%) is the price of walks whose CPU dropped ~20% in the same change.

